### PR TITLE
Add init_linear_with_centroids parameter

### DIFF
--- a/util.py
+++ b/util.py
@@ -275,6 +275,7 @@ def get_test_args():
     parser.add_argument('--num_updates', type=int, default=5)
     parser.add_argument('--num_test_batches', type=int, default=None)
     parser.add_argument('--lr', type=float, default=1e-3)
+    parser.add_argument('--init_linear_with_centroids', default=False, action='store_true')
     parser.add_argument('--bert_lr', type=float, default=5e-5)
     parser.add_argument('--distance', choices=['euclidean', 'cosine'], default='euclidean')
     args = parser.parse_args()


### PR DESCRIPTION
Old branch not yet merged, used to initialize MultiTask learner's classifier with prototype centroids.